### PR TITLE
Improved the Ruby code

### DIFF
--- a/ruby/heap.rb
+++ b/ruby/heap.rb
@@ -1,45 +1,41 @@
-N = 10000000.freeze
-$h = Array.new
+require 'benchmark'
 
-def pushDown(pos, n)
-  while 2*pos + 1 < n
-    j = 2*pos + 1
-    if (j+1 < n) and ($h[j+1] > $h[j])
+def push_down(heap, pos, n)
+  while (2 * pos + 1) < n
+    j = 2 * pos + 1
+
+    if (j + 1 < n) and (heap[j + 1] > heap[j])
       j += 1
     end
 
-    break unless $h[pos] < $h[j]
+    break unless heap[pos] < heap[j]
 
-    $h[pos], $h[j] = $h[j], $h[pos]
+    tmp = heap[pos]
+    heap[pos] = heap[j]
+    heap[j] = tmp
+
     pos = j
   end
 end
 
-def main
-  start = Time.now
 
-  N.times do |i|
-    $h << i
+def heapsort(size)
+  heap = (0...size).to_a
+
+  (size / 2).downto(0) do |i|
+    push_down heap, i, size
   end
 
-  (N/2).downto(0) do |i|
-    pushDown i, N
+  (size - 1).downto(1) do |n|
+    tmp = heap[0]
+    heap[0] = heap[n]
+    heap[n] = tmp
+
+    push_down heap, 0, n
   end
 
-  n = N
-  while n > 1
-    $h[0], $h[n-1] = $h[n-1], $h[0]
-    n -= 1
-    pushDown 0, n
-  end
-
-  N.times do |i|
-    raise "h[i] != i" unless $h[i] == i
-  end
-
-  puts "Done in #{((Time.now - start) * 1000).to_i}"
+  raise "Array not sorted" unless heap.each.with_index.all? { |element, index| element == index }
 end
 
-begin
-  main
-end
+n = 10_000_000
+puts Benchmark.measure { heapsort n }


### PR DESCRIPTION
I rewrote the Ruby code. It had two serious flaws.

First, it was in no way idiomatic. The standard ruby naming convention was not adhered to and it used a global variable, probably because the author was not aware of some specifics in the scoping in Ruby. I've also changed a bunch of things to be way more idiomatic, like constructing the initial array or verifying its contents. It should work on both Ruby 1.9 and Ruby 2.0.

Second, I changed the way exchanging of the elements was done. It abuses the splat assignments. Writing `a, b = b, a` creates two arrays in Ruby. Most of the time in the algorithm was actually spent on those two lines.

With both changes, I dropped down the running time on my machine from `256.65s` to `49.84s`. That's five times faster.

That's also twice as fast than the Python implementation (I modified the exchange in Python the same way, but it made no difference - apparently Python is smart enough).

On a related note, comparing integers in Ruby is extra slow, because you can redefine `Numeric#<` and it basically has to do method lookup (or at least cache the result and check if the cache is valid).
