### PR TITLE
Use Uint32Array() instead of Array()

### DIFF
--- a/javascript/heap.js
+++ b/javascript/heap.js
@@ -1,6 +1,6 @@
 var N = 10000000;
 
-var h = new Array(N);
+var h = new Uint32Array(N);
 
 function pushDown(pos, n) {
     while (2 * pos + 1 < n) {


### PR DESCRIPTION
This speeds JavaScript performance up to 1330ms and cuts memory usage by a factor of three.
