### PR TITLE
Add rust implementation

### DIFF
--- a/rust/heap.rs
+++ b/rust/heap.rs
@@ -1,0 +1,52 @@
+use std::*;
+
+const N : usize = 10000000;
+
+static mut h : [i32; N] = [0; N];
+
+fn push_down(mut pos : usize, n : usize)
+{
+    while 2 * pos + 1 < n
+    {
+        unsafe {
+            let mut j = 2 * pos + 1;
+            if j + 1 < n && h[j + 1] > h[j] {
+                j = j + 1;
+            }
+            if h[pos] >= h[j] {
+                break;
+            }
+            mem::swap(&mut h[pos], &mut h[j]);
+            pos = j;
+        }
+    }
+}
+
+fn main() {
+    let start = time::Instant::now();
+
+    for i in 0..N {
+        unsafe { h[i] = i as i32 };
+    }
+
+    for i in (0..(N/2 + 1)).rev() {
+        push_down(i, N);
+    }
+    
+    let mut n = N;
+    while n > 1 {
+        unsafe { mem::swap(&mut h[0], &mut h[n - 1]); }
+        n = n - 1;
+        push_down(0, n);
+    }
+
+    for i in 0..N {
+        unsafe { assert!(h[i] == i as i32); }
+    }
+
+    let duration = start.elapsed();
+    let ms_taken = duration.as_secs() * 1000
+        + (duration.subsec_nanos() as u64) / 1000000;
+
+    println!("Done in {}", ms_taken);
+}


### PR DESCRIPTION
Although there is already a pull request open for this (#13), with the newest release of Rust (1.8.0) the `std::time::Instant` struct is stable in the standard library, thus allowing a more idiomatic implementation that (to the best of my ability) closely matches the C++ implementation already in the repository.

There is no longer any need for cargo or anything of that nature, and the code is simplified. The output is milliseconds as every other implementation.

It should be noted that Rust relies heavily on compiler optimizations, so `rustc -O heap.rs` is preferred.

As a side note, I hope Rust can join the Codeforces language family soon! I am excited to use it on my favorite online judging platform.
