### PR TITLE
Julia version of heap added

### DIFF
--- a/julia/heap.jl
+++ b/julia/heap.jl
@@ -1,0 +1,37 @@
+using Dates
+
+function pushDown(h, pos, n)
+    while 2 * pos <= n
+        j = 2 * pos
+        if j + 1 <= n && h[j+1] > h[j]
+            j += 1
+        end
+        h[pos] >= h[j] && break
+        h[pos], h[j] = h[j], h[pos]
+        pos = j
+    end
+end
+
+function main()
+    start = now()
+    N = 10000000
+    h = collect(0:N-1)
+    for i in div(N, 2)+1:-1:1
+        pushDown(h, i, N)
+    end
+    
+    n = N
+    while n > 1
+        h[1], h[n] = h[n], h[1]
+        n -= 1
+        pushDown(h, 1, n)
+    end
+    
+    for i in 1:N
+        @assert h[i] == i-1
+    end
+
+    println("Done in ", Dates.value(now() - start))
+end
+
+main()


### PR DESCRIPTION
I saw a thread on `julia` at https://codeforces.com/blog/entry/79 and wanted to help out. This code is a slightly modified copy&paste of `python3` version. The biggest difference is `julia`'s 1-based indexing. On my machine running time was within a factor of 2 slower than `c++` version.

Also, I've posted a solution to the "Theatre square" problem mentioned in the thread. https://gist.github.com/artemsolod/3eb48e75b06216fd0af317546c793480

`julia` binaries are available here https://julialang.org/downloads/. The command to run code is `julia heap.jl`

One thing to note is that `julia` JIT-compiles code so it seems that every test-case would spend some time recompiling the solution.

Hope this helps!